### PR TITLE
fix nvim_set_option_value

### DIFF
--- a/lua/kustomize/build.lua
+++ b/lua/kustomize/build.lua
@@ -7,7 +7,7 @@ local function configure_buffer()
   local win, buf = utils.create_output()
   vim.api.nvim_win_set_buf(win, buf)
   vim.api.nvim_buf_set_name(buf, "Kustomize #" .. buf)
-  vim.api.nvim_set_option_value("filetype", "yaml", { buf, buf })
+  vim.api.nvim_set_option_value("filetype", "yaml", { buf = buf })
   utils.delete_output_keybinding(win, buf)
   return buf
 end


### PR DESCRIPTION
There is a bug introduced by [this change](https://github.com/Allaman/kustomize.nvim/pull/43/files) which cause `KustomizeBuild` to fail:

![image](https://github.com/Allaman/kustomize.nvim/assets/7448852/b860eb01-b5d7-4610-af75-c54e855dcc26)

This PR fix buf option:

![image](https://github.com/Allaman/kustomize.nvim/assets/7448852/e0fc7654-26cb-4b24-a132-06273390cf07)

neovim version: v0.10.0-dev-1911+g104565909

