### PR TITLE
Fix health check using wrong utils function to check for executables

### DIFF
--- a/lua/kustomize/health.lua
+++ b/lua/kustomize/health.lua
@@ -60,7 +60,7 @@ M.check = function()
   end
 
   for k, v in pairs(programs) do
-    if not utils.is_executable_available(k) then
+    if not utils.check_exec(k) then
       if v.required then
         _error(string.format(exec_not_found_template, k, v.desc))
       else


### PR DESCRIPTION
`:checkhealth` was showing an error for kustomize.nvim:

```
==============================================================================
kustomize:                                 require("kustomize.health").check()

System configuration ~
- ✅ OK This config will work with your Neovim version
- ✅ OK nvim-lua/plenary.nvim found
- ✅ OK nvim-lua/plenary.nvim found
- ✅ OK L3MON4D3/LuaSnip found
- ✅ OK nvim-treesitter/nvim-treesitter found
- ❌ ERROR Failed to run healthcheck for "kustomize" plugin. Exception:
  .../share/nvim/lazy/kustomize.nvim/lua/kustomize/health.lua:63: attempt to call field 'is_executable_available' (a nil value)
```

`health.lua` uses a non existing function `is_executable_available` from `utils.lua`. 

This PR replaces this with the correct call for `check_exec` and fixes the issue.
